### PR TITLE
로그인 성공 시 userID만 반환하도록 수정

### DIFF
--- a/src/main/java/com/example/inkspire/controller/MemberController.java
+++ b/src/main/java/com/example/inkspire/controller/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
 
     /* 로그인 */
     @PostMapping("/login")
-    public ResponseEntity<DataResponseDto<MemberInfoDto>> login(@Validated @RequestBody Map<String, String> map) {
+    public ResponseEntity<DataResponseDto<Long>> login(@Validated @RequestBody Map<String, String> map) {
         return new ResponseEntity<>(memberService.join(map.get("email"), map.get("password")), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/inkspire/service/MemberService.java
+++ b/src/main/java/com/example/inkspire/service/MemberService.java
@@ -38,12 +38,12 @@ public class MemberService {
         return memberRepository.findByEmail(memberSignupDto.getEmail()) == null;
     }
 
-    public DataResponseDto<MemberInfoDto> join(String email, String password) {
+    public DataResponseDto<Long> join(String email, String password) {
         Member member = memberRepository.findByEmail(email);
 
         if (!member.getPassword().equals(password)) {
             throw new GeneralException(ResponseCode.BAD_REQUEST, "로그인 실패");
         }
-        return DataResponseDto.of(new MemberInfoDto(member.getId(), member.getEmail(), member.getNickname()), "로그인 성공");
+        return DataResponseDto.of(member.getId(), "로그인 성공");
     }
 }


### PR DESCRIPTION
### Response example

1) 로그인 성공시

```json
{
    "success": true,
    "code": 200,
    "message": "로그인 성공",
    "data": 8
}
```

2) 로그인 실패

```json
{
    "success": false,
    "code": 400,
    "message": "로그인 실패"
}
```